### PR TITLE
Removed parameters of ensure_packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ define archive (
   $packages = [ 'curl', 'unzip', 'tar', ]
 
   # install additional packages if missing
-  ensure_packages($packages, {ensure => installed})
+  ensure_packages($packages)
 
   archive::download {"${name}.${extension}":
     ensure          => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,7 @@ define archive (
   $exec_path        = ['/usr/local/bin', '/usr/bin', '/bin']) {
 
   # list of packages needed for download and extraction
-  $packages = [ 'curl', 'unzip', 'tar', ]
+  $packages = [ 'curl', 'unzip', 'tar' ]
 
   # install additional packages if missing
   ensure_packages($packages)


### PR DESCRIPTION
To avoid a duplicate declaration of a resource better use ensure_packages without params.
